### PR TITLE
Improved optimisations within misc.lua

### DIFF
--- a/liro/gamemode/liro/misc.lua
+++ b/liro/gamemode/liro/misc.lua
@@ -1,7 +1,3 @@
 -- Liro - liro/misc.lua
 
--- Micro optimisations
-local math = math
-local os = os
-
 math.randomseed(os.time())


### PR DESCRIPTION
os and math are only referenced once. To stop the uncessary use of memory, the local variables have been removed.